### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A starter template for building your own Model Context Protocol (MCP) server. This template provides the basic structure and setup needed to create custom MCPs that can be used with Cursor or Claude Desktop.
 
+<a href="https://glama.ai/mcp/servers/vnt96edg3a">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/vnt96edg3a/badge" alt="Server Template MCP server" />
+</a>
+
 ## Features
 
 - Basic MCP server setup with TypeScript


### PR DESCRIPTION
This PR adds a badge for the [MCP Server Template](https://glama.ai/mcp/servers/vnt96edg3a) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/vnt96edg3a">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/vnt96edg3a/badge" alt="Server Template MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.